### PR TITLE
more strict private methods pattern to fix compatibility with other gems

### DIFF
--- a/lib/acts_as_singleton.rb
+++ b/lib/acts_as_singleton.rb
@@ -22,7 +22,7 @@ module ActiveRecord
     # This pattern matches methods that should be made private because they
     # should not be used in singleton classes.
     PRIVATE = \
-      /^all$|create(?!_reflection|_callback)|find(?!er|_callback)|firs|mini|max|new|d_sco|^upd/
+      /^all$|^create(?!_reflection|_callback)|^find(?!er|_callback)|^first|^minimum$|^maximum$|^new$|d_sco|^update/
 
     def self.included(model)
       model.class_eval do


### PR DESCRIPTION
I found this patch in iquest/acts_as_singleton@e33f883b5e7f01521989867c36e97eb395ba70fc
